### PR TITLE
[feat] Created Project List and Add, Edit Sheet UI #6

### DIFF
--- a/i-scheduler/i-scheduler/AddSheet.swift
+++ b/i-scheduler/i-scheduler/AddSheet.swift
@@ -1,0 +1,61 @@
+//
+//  AddSheet.swift
+//  i-scheduler
+//
+//  Created by 권은빈 on 2021/12/08.
+//
+
+import SwiftUI
+
+struct AddSheet: View {
+    
+    private var subject: Subject
+    private var prefix: String
+    
+    @State var addData: TestProject
+    
+    init(subject: Subject) {
+        self.subject = subject
+        
+        if subject == .project {
+            self.prefix = "프로젝트"
+        } else {
+            self.prefix = "할 일"
+        }
+        
+        _addData = State(initialValue: TestProject(name: "", summary: ""))
+    }
+    
+    var body: some View {
+        VStack {
+            TopBar(bar: .addSheet, subject: subject, data: addData)
+            VStack {
+                Text("\(prefix) 이름")
+                TextField("", text: $addData.name)
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal, 30.0)
+            }
+            .padding()
+            VStack {
+                Text("\(prefix) 설명")
+                TextEditor(text: $addData.summary)
+                    .modifier(TextEditorModifier())
+            }
+            .padding()
+            VStack {
+                DatePicker("시작 날짜", selection: $addData.startDate, displayedComponents: .date)
+                DatePicker("종료 날짜", selection: $addData.endDate, in: PartialRangeFrom(addData.startDate), displayedComponents: .date)
+            }
+            .padding(.horizontal, 50.0)
+            .padding(.top, 20.0)
+            
+            Spacer()
+        }
+    }
+}
+
+//struct AddSheet_Previews: PreviewProvider {
+//    static var previews: some View {
+//        AddSheet(subject: .project)
+//    }
+//}

--- a/i-scheduler/i-scheduler/EditSheet.swift
+++ b/i-scheduler/i-scheduler/EditSheet.swift
@@ -1,0 +1,82 @@
+//
+//  EditSheet.swift
+//  i-scheduler
+//
+//  Created by 권은빈 on 2021/12/08.
+//
+
+import SwiftUI
+
+struct EditSheet: View {
+    
+    private var subject: Subject
+    private var prefix: String
+    
+    @State private var editedProject: TestProject
+    
+    init(subject: Subject, editData: TestProject) {
+        self.subject = subject
+        
+        if subject == .project {
+            self.prefix = "프로젝트"
+        } else {
+            self.prefix = "할 일"
+        }
+        
+        _editedProject = State(initialValue: editData)
+    }
+    
+    var body: some View {
+        VStack {
+            TopBar(bar: .editSheet, subject: subject, data: editedProject)
+            VStack {
+                Text("\(prefix) 이름")
+                TextField("", text: $editedProject.name)
+                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal, 30.0)
+            }
+            .padding()
+            VStack {
+                Text("\(prefix) 설명")
+                TextEditor(text: $editedProject.summary)
+                    .modifier(TextEditorModifier())
+            }
+            .padding()
+            VStack {
+                DatePicker("시작 날짜", selection: $editedProject.startDate, displayedComponents: .date)
+                DatePicker("종료 날짜", selection: $editedProject.endDate, in: PartialRangeFrom(editedProject.startDate), displayedComponents: .date)
+            }
+            .padding(.horizontal, 50.0)
+            .padding(.top, 20.0)
+            
+            Toggle("\(prefix) 완료", isOn: $editedProject.isFinished)
+                .toggleStyle(.switch)
+                .padding(.horizontal, 50.0)
+                .padding(.top, 20.0)
+            
+            Spacer()
+        }
+    }
+}
+
+struct TextEditorModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(Color.clear)
+            .foregroundColor(Color.black)
+            .font(.body)
+            .lineSpacing(5)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 100, alignment: .center)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+            )
+            .padding(.horizontal, 30.0)
+    }
+}
+
+//struct EditSheet_Previews: PreviewProvider {
+//    static var previews: some View {
+//        EditSheet(subject: .task)
+//    }
+//}

--- a/i-scheduler/i-scheduler/ProjectGrid.swift
+++ b/i-scheduler/i-scheduler/ProjectGrid.swift
@@ -1,0 +1,26 @@
+//
+//  ProjectGrid.swift
+//  i-scheduler
+//
+//  Created by 권은빈 on 2021/12/08.
+//
+
+import SwiftUI
+
+
+// Temporary Project Grid View...
+
+struct ProjectGrid: View {
+    
+    @State var row: String = ""
+    
+    var body: some View {
+        Text("row \(row)...")
+    }
+}
+
+struct ProjectGrid_Previews: PreviewProvider {
+    static var previews: some View {
+        ProjectGrid()
+    }
+}

--- a/i-scheduler/i-scheduler/ProjectList.swift
+++ b/i-scheduler/i-scheduler/ProjectList.swift
@@ -1,0 +1,98 @@
+//
+//  ProjectList.swift
+//  i-scheduler
+//
+//  Created by 권은빈 on 2021/12/08.
+//
+
+import SwiftUI
+
+// Test Data to display
+struct TestProject: Identifiable, Hashable {
+    var id: UUID = UUID()
+    var name: String
+    var summary: String
+    var startDate: Date = Date()
+    var endDate: Date = Date()
+    var isFinished: Bool = false
+}
+
+var testProjects: [TestProject] = {
+    let dataset = ["i-scheduler", "42 subjects", "swift study"]
+    var testProjectList = [TestProject]()
+    
+    for name in dataset {
+        testProjectList.append(TestProject(name: name, summary: "summary of \(name)"))
+    }
+    
+    return testProjectList
+}()
+
+
+// MARK: - EditButton 사용하지 않고 Custom Button 만들어서 toolBar에서 사용하는 경우, 화면의 왼편과 오른편이 나뉘는 현상 발생...
+// EditButton -> 영어, Custom Action 서치 못 함
+
+struct ProjectList: View {
+    
+    @Environment(\.editMode) private var editMode: Binding<EditMode>?
+    @State private var isEditing: Bool = false
+    @State private var isTapped: Bool = false
+    @State private var showAddSheet: Bool = false
+    @State private var editData: TestProject = TestProject(name: "", summary: "")
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                List(testProjects, id: \.self) { project in
+                    NavigationLink(destination: ProjectGrid(row: project.name),
+                                   label: {
+                        Text(project.name)
+                            .font(.title3)
+                            .padding(8.0)
+                    })
+                    .onTapGesture {
+                        if self.editMode?.wrappedValue == .active {
+                            editData = project
+                            isTapped.toggle()
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .navigationTitle(isEditing ? "프로젝트 선택" : "내 프로젝트")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading, content: {
+                        Button(isEditing ? "완료" : "수정") {
+                            self.editMode?.wrappedValue.toggle()
+                            self.isEditing.toggle()
+                        }
+                    })
+                    ToolbarItem(placement: .navigationBarTrailing, content: {
+                        if !isEditing {
+                            Button("추가") {
+                                showAddSheet.toggle()
+                            }
+                            .sheet(isPresented: $showAddSheet, content: {
+                                AddSheet(subject: .project)
+                            })
+                        }
+                    })
+                }
+                .sheet(isPresented: $isTapped, content: {
+                    EditSheet(subject: .project, editData: editData)
+                })
+            }
+        }
+    }
+}
+
+extension EditMode {
+    mutating func toggle() {
+        self = self == .active ? .inactive : .active
+    }
+}
+
+//struct ProjectList_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ProjectList()
+//    }
+//}

--- a/i-scheduler/i-scheduler/TopBar.swift
+++ b/i-scheduler/i-scheduler/TopBar.swift
@@ -1,0 +1,101 @@
+//
+//  TopBar.swift
+//  i-scheduler
+//
+//  Created by 권은빈 on 2021/12/08.
+//
+
+import SwiftUI
+
+enum Bar {
+    case editSheet
+    case addSheet
+}
+
+enum Subject {
+    case project
+    case task
+}
+
+struct TopBar: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    var barText: String
+    var leftBtnLabel: String
+    var rightBtnLabel: String
+    var saveData: TestProject
+    
+    init(bar: Bar, subject: Subject, data: TestProject) {
+        var prefix = ""
+        
+        if subject == .project {
+            prefix = "프로젝트 "
+        } else if subject == .task {
+            prefix = "할 일 "
+        }
+        
+        switch bar {
+        case .editSheet:
+            self.barText = prefix + "수정"
+            self.leftBtnLabel = "닫기"
+            self.rightBtnLabel = "저장"
+        case .addSheet:
+            self.barText = prefix + "생성"
+            self.leftBtnLabel = "닫기"
+            self.rightBtnLabel = "저장"
+        }
+        
+        self.saveData = data
+    }
+    
+    var body: some View {
+        HStack {
+            
+            Button(leftBtnLabel) {
+                print("left button - 닫기")
+                presentationMode.wrappedValue.dismiss()
+            }
+            .padding()
+
+            Spacer()
+            Text(barText)
+                .font(.system(size: 20))
+            Spacer()
+            
+            Button(rightBtnLabel) {
+                print("right button - 저장")
+                
+
+                if let i = findEditDataIndex() {
+                    testProjects[i].name = saveData.name
+                    testProjects[i].summary = saveData.summary
+                }
+                else {
+                    testProjects.append(saveData)
+                }
+                
+                print("save Data: \(saveData)")
+                presentationMode.wrappedValue.dismiss()
+            }
+            .padding()
+        }
+    }
+    
+    func findEditDataIndex() -> Int? {
+        
+        for i in 0..<testProjects.count {
+            if testProjects[i].id == saveData.id {
+                return i
+            }
+        }
+        
+        return nil
+    }
+}
+
+//
+//struct TopBar_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TopBar(bar: Bar.editSheet, subject: Subject.project)
+//    }
+//}


### PR DESCRIPTION
- Project List 뷰 생성
  - 구조체로 만든 목 데이터로 리스트 UI 생성
  - 상단의 버튼은 ToolbarItem으로 생성
    - EditButton() 대신 custom Button 생성해 사용
    - 해당 방식으로 디바이스의 왼편과 오른편의 탭 적용 범위가 나뉘는 이슈 발생

- Add, Edit Sheet 뷰 생성
  - 구조체로 만든 목 데이터 활용
  - Edit 뷰에선, 수정 전 데이터를 기본으로 세팅
  - DatePicker는 현재 Start, End 두 개로 분리했으나 추후 [멀티 피커](https://github.com/peterent/MultiDatePicker)로 발전할지 여부 논의

**스크린샷**

| ![Simulator Screen Shot - iPhone 11 Pro - 2021-12-09 at 22 54 52](https://user-images.githubusercontent.com/75126613/145409718-21fc2bc6-50d8-44f2-90e2-049f5863b65c.png)  | ![Simulator Screen Shot - iPhone 11 Pro - 2021-12-09 at 22 54 57](https://user-images.githubusercontent.com/75126613/145409723-b1f13c6b-27ae-4fdf-ad51-78fd882d79ed.png)  |
|---|---|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-12-09 at 22 55 04](https://user-images.githubusercontent.com/75126613/145409847-1f71c2fe-a500-4a11-9fa4-8a80af0df077.png)  | ![Simulator Screen Shot - iPhone 11 Pro - 2021-12-09 at 22 56 27](https://user-images.githubusercontent.com/75126613/145409854-79976547-6820-4d98-b35c-461ac849536e.png)  |
