### PR TITLE
[feat] Created Popup, DailyTaskList, DailyTaskRowView, TaskDetailView #10

### DIFF
--- a/i-scheduler/i-scheduler/DailyTaskList.swift
+++ b/i-scheduler/i-scheduler/DailyTaskList.swift
@@ -1,0 +1,83 @@
+//
+//  DailyTaskList.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/07.
+//
+
+import SwiftUI
+
+struct DailyTaskList: View {
+    @Environment(\.managedObjectContext) var context
+    @FetchRequest var tasks: FetchedResults<Task>
+    @Binding var isPresented: Bool
+    var projectId: UUID
+    
+    init(isPresented: Binding<Bool>, projectId: UUID, date: Date) {
+        self._isPresented = isPresented
+        self.projectId = projectId
+        // func in Task extension
+        let request = Task.fetchRequest(NSPredicate(format: "project.id = %@ and startDate <= %@ and endDate >= %@", projectId as CVarArg, date as CVarArg, date as CVarArg))
+        _tasks = FetchRequest(fetchRequest: request)
+    }
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                if !tasks.isEmpty {
+                    List {
+                        ForEach(tasks) { task in
+                            DailyTaskRowView(task: task)
+                        }
+                        .onDelete(perform: deleteTask(at:))
+                    }
+                } else {
+                    Text("No Tasks Today")
+                }
+            }
+            .navigationBarTitle("오늘의 할 일")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { cancel }
+                ToolbarItem(placement: .navigationBarTrailing) { add }
+            }
+            .sheet(isPresented: $taskEditorIsPresented) {
+                // replace with 은빈's Editor
+                FakeTaskEditor(projectId: projectId)
+                    .environment(\.managedObjectContext, context)
+            }
+        }
+    }
+    
+    private func deleteTask(at indexSet: IndexSet) {
+        for index in indexSet {
+            // func in Task extension
+            let task = Task.withId(tasks[index].id!, context: context)
+            context.delete(task)
+        }
+        try? context.save()
+    }
+    
+    private var cancel: some View {
+        Button("취소") {
+            withAnimation {
+                isPresented = false
+            }
+        }
+    }
+    
+    @State private var taskEditorIsPresented = false
+    private var add: some View {
+        Button {
+            taskEditorIsPresented = true
+        } label: {
+            Image(systemName: "plus")
+        }
+    }
+    
+}
+
+//struct DailyTaskList_Previews: PreviewProvider {
+//    static var previews: some View {
+//        DailyTaskList()
+//    }
+//}

--- a/i-scheduler/i-scheduler/DailyTaskRowView.swift
+++ b/i-scheduler/i-scheduler/DailyTaskRowView.swift
@@ -1,0 +1,65 @@
+//
+//  DailyTaskRowView.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/07.
+//
+
+import SwiftUI
+
+struct DailyTaskRowView: View {
+    @FetchRequest var tasks: FetchedResults<Task>
+    @Environment(\.managedObjectContext) var context
+    private var task: Task? { tasks.first }
+    
+    init(task: Task) {
+        // func in Task extension
+        let request = Task.fetchRequest(NSPredicate(format: "id = %@", (task.id ?? UUID()) as CVarArg))
+        _tasks = FetchRequest(fetchRequest: request)
+    }
+    
+    var body: some View {
+        if let task = task {
+            NavigationLink(destination: TaskDetailView(task: task)) {
+                HStack {
+                    checkbox(for: task)
+                    description(of: task)
+                }
+                .foregroundColor(task.isFinished ? .gray : .black)
+            }
+        }
+    }
+    
+    private func checkbox(for task: Task) -> some View {
+        Button {
+            save()
+        } label: {
+            Image(systemName: task.isFinished ? "checkmark.square" : "square")
+                .scaleEffect(1.3)
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private func description(of task: Task) -> some View{
+        VStack(alignment: .leading) {
+            Text(task.name ?? "")
+                .font(.headline)
+                .strikethrough(task.isFinished)
+            // var in Task extension
+            Text(task.startToEnd)
+                .strikethrough(task.isFinished)
+            Text(task.summary ?? "")
+                .strikethrough(task.isFinished)
+                .lineLimit(2)
+        }
+        .padding(.leading)
+    }
+    
+    private func save() {
+        if let task = tasks.first {
+            task.isFinished.toggle()
+            try? context.save()
+        }
+    }
+}
+

--- a/i-scheduler/i-scheduler/Popup.swift
+++ b/i-scheduler/i-scheduler/Popup.swift
@@ -1,0 +1,65 @@
+//
+//  Popup.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/07.
+//
+
+import SwiftUI
+
+struct Popup: ViewModifier {
+    @Binding var isPresented: Bool
+    @Environment(\.managedObjectContext) var context
+    var projectId: UUID
+    var size: CGSize
+    var date: Date
+
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(isPresented ? popupContent() : nil)
+    }
+    
+    private func popupContent() -> some View {
+        ZStack {
+            withAnimation {
+                DailyTaskList(isPresented: $isPresented, projectId: projectId, date: date)
+                    .clipShape(RoundedRectangle(cornerRadius: 30))
+                    .overlay(RoundedRectangle(cornerRadius: 30).stroke(Color.gray.opacity(0.2), lineWidth: 1))
+                    .shadow(color: Color.gray.opacity(0.4), radius: 4)
+                    .environment(\.managedObjectContext, context)
+            }
+        }
+        .frame(width: size.width * 0.8, height: size.height * 0.75)
+        .transition(.move(edge: .bottom))
+    }
+}
+
+
+
+extension View {
+    func popup(isPresented: Binding<Bool>, projectId: UUID, size: CGSize, date: Date) -> some View {
+        self.modifier(Popup(isPresented: isPresented, projectId: projectId, size: size, date: date))
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//struct Popup_Previews: PreviewProvider {
+//    static var previews: some View {
+//        Popup()
+//    }
+//}

--- a/i-scheduler/i-scheduler/TaskDetailView.swift
+++ b/i-scheduler/i-scheduler/TaskDetailView.swift
@@ -1,0 +1,49 @@
+//
+//  TaskDetailView.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/08.
+//
+
+import SwiftUI
+
+struct TaskDetailView: View {
+    var task: Task
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(task.isFinished ? "진행 상태 : 완료!" : "진행 상태 : 진행 중!")
+                    .foregroundColor(.green)
+                    .bold()
+                Text(task.name!)
+                    .font(.largeTitle)
+                Text(task.startToEnd)
+                Text("")
+                Text(task.summary!)
+                Spacer()
+            }
+            .padding(.leading)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .toolbar {
+            // functioning not implemetened yet
+            Button("Edit") { print("edit") }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+//struct TaskDetailView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TaskDetailView()
+//    }
+//}


### PR DESCRIPTION
**DailyTaskList**
- 모달뷰(Popup ViewModifier 만들어서 적용)로 뜸
- TaskRowView로 각 태스크 설명
- 코어 데이터 연동
- 왼쪽 위 닫기 버튼, 오른쪽 위 태스크 추가 버튼(둘 다 기능 구현)

**TaskDetailView**
- 태스크 완료여부, 제목, 설명 다 텍스트로 표현
- 추후 구성 다시 논의 필요
- 왼쪽 상단 뒤로 가기, 오른쪽 상단 수정 버튼(수정 버튼은 기능 미구현)