### PR TITLE
[feat] added Project, Task extensions and setup for core data #15

### DIFF
--- a/i-scheduler/i-scheduler.xcodeproj/project.pbxproj
+++ b/i-scheduler/i-scheduler.xcodeproj/project.pbxproj
@@ -17,8 +17,10 @@
 		93989522276339E400BF6F59 /* DailyTaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93989518276339E400BF6F59 /* DailyTaskRowView.swift */; };
 		93989523276339E400BF6F59 /* ProjectCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93989519276339E400BF6F59 /* ProjectCalendarView.swift */; };
 		93989524276339E400BF6F59 /* DailyTaskList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9398951A276339E400BF6F59 /* DailyTaskList.swift */; };
-		A44E7AAD275DDC7700D92696 /* i-scheduler.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E7AAB275DDC7700D92696 /* i-scheduler.xcdatamodeld */; };
 		A44E7ACE275DE32E00D92696 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A44E7ACD275DE32E00D92696 /* Persistence.swift */; };
+		A45A93F827637DFA008F626F /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A93F727637DFA008F626F /* Project.swift */; };
+		A45A93FA27637DFF008F626F /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45A93F927637DFF008F626F /* Task.swift */; };
+		A45A940327637E95008F626F /* i_scheduler.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A45A940127637E95008F626F /* i_scheduler.xcdatamodeld */; };
 		A87FA85E275DD47100A77363 /* i_schedulerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87FA85D275DD47100A77363 /* i_schedulerApp.swift */; };
 		A87FA860275DD47100A77363 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87FA85F275DD47100A77363 /* ContentView.swift */; };
 		A87FA862275DD47200A77363 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A87FA861275DD47200A77363 /* Assets.xcassets */; };
@@ -36,8 +38,10 @@
 		93989518276339E400BF6F59 /* DailyTaskRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyTaskRowView.swift; sourceTree = "<group>"; };
 		93989519276339E400BF6F59 /* ProjectCalendarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectCalendarView.swift; sourceTree = "<group>"; };
 		9398951A276339E400BF6F59 /* DailyTaskList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyTaskList.swift; sourceTree = "<group>"; };
-		A44E7AAC275DDC7700D92696 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		A44E7ACD275DE32E00D92696 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
+		A45A93F727637DFA008F626F /* Project.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		A45A93F927637DFF008F626F /* Task.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
+		A45A940227637E95008F626F /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		A87FA85A275DD47100A77363 /* i-scheduler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "i-scheduler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A87FA85D275DD47100A77363 /* i_schedulerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = i_schedulerApp.swift; sourceTree = "<group>"; };
 		A87FA85F275DD47100A77363 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -85,10 +89,12 @@
 				93989512276339E300BF6F59 /* Popup.swift */,
 				93989519276339E400BF6F59 /* ProjectCalendarView.swift */,
 				93989517276339E400BF6F59 /* ProjectGrid.swift */,
+				A45A93F727637DFA008F626F /* Project.swift */,
+				A45A93F927637DFF008F626F /* Task.swift */,
 				93989515276339E400BF6F59 /* ProjectList.swift */,
 				93989516276339E400BF6F59 /* TaskDetailView.swift */,
 				93989513276339E400BF6F59 /* TopBar.swift */,
-				A44E7AAB275DDC7700D92696 /* i-scheduler.xcdatamodeld */,
+				A45A940127637E95008F626F /* i_scheduler.xcdatamodeld */,
 				A87FA861275DD47200A77363 /* Assets.xcassets */,
 				A87FA863275DD47200A77363 /* Preview Content */,
 			);
@@ -177,13 +183,15 @@
 				9398951C276339E400BF6F59 /* Popup.swift in Sources */,
 				A87FA860275DD47100A77363 /* ContentView.swift in Sources */,
 				93989521276339E400BF6F59 /* ProjectGrid.swift in Sources */,
+				A45A940327637E95008F626F /* i_scheduler.xcdatamodeld in Sources */,
 				9398951E276339E400BF6F59 /* AddSheet.swift in Sources */,
 				93989523276339E400BF6F59 /* ProjectCalendarView.swift in Sources */,
 				93989520276339E400BF6F59 /* TaskDetailView.swift in Sources */,
 				A44E7ACE275DE32E00D92696 /* Persistence.swift in Sources */,
+				A45A93FA27637DFF008F626F /* Task.swift in Sources */,
+				A45A93F827637DFA008F626F /* Project.swift in Sources */,
 				9398951B276339E400BF6F59 /* EditSheet.swift in Sources */,
 				A87FA85E275DD47100A77363 /* i_schedulerApp.swift in Sources */,
-				A44E7AAD275DDC7700D92696 /* i-scheduler.xcdatamodeld in Sources */,
 				93989522276339E400BF6F59 /* DailyTaskRowView.swift in Sources */,
 				93989524276339E400BF6F59 /* DailyTaskList.swift in Sources */,
 				9398951F276339E400BF6F59 /* ProjectList.swift in Sources */,
@@ -391,13 +399,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		A44E7AAB275DDC7700D92696 /* i-scheduler.xcdatamodeld */ = {
+		A45A940127637E95008F626F /* i_scheduler.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				A44E7AAC275DDC7700D92696 /* Model.xcdatamodel */,
+				A45A940227637E95008F626F /* Model.xcdatamodel */,
 			);
-			currentVersion = A44E7AAC275DDC7700D92696 /* Model.xcdatamodel */;
-			path = "i-scheduler.xcdatamodeld";
+			currentVersion = A45A940227637E95008F626F /* Model.xcdatamodel */;
+			name = i_scheduler.xcdatamodeld;
+			path = "../../../forked_i-scheduler/i-scheduler/i-scheduler/i_scheduler.xcdatamodeld";
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/i-scheduler/i-scheduler/Project.swift
+++ b/i-scheduler/i-scheduler/Project.swift
@@ -1,0 +1,67 @@
+//
+//  Project.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/08.
+//
+
+import CoreData
+import SwiftUI
+
+extension Project: Comparable {
+    public static func < (lhs: Project, rhs: Project) -> Bool {
+        lhs.name < rhs.name
+    }
+    
+    // MARK: - Fetching From CoreData
+    
+    static func withId(_ id: UUID, context: NSManagedObjectContext) -> Project {
+        let request = fetchRequest(NSPredicate(format: "projectId_ = %@", id as CVarArg))
+        let project = (try? context.fetch(request)) ?? []
+        if let project = project.first {
+            return project
+        } else {
+            // TODO: throw an error instead?
+            let newProject = Project(context: context)
+            newProject.projectId = id
+            newProject.tasks = []
+            return newProject
+        }
+    }
+    
+    static func fetchRequest(_ predicate: NSPredicate) -> NSFetchRequest<Project> {
+        let request = NSFetchRequest<Project>(entityName: "Project")
+        request.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
+        request.predicate = predicate
+        return request
+    }
+    
+    // MARK: - Nil-coalesced Properties
+    
+    var projectId : UUID {
+        // TODO: maybe throw error when nil?
+        get { projectId_ ?? UUID() }
+        set { projectId_ = newValue }
+    }
+    var name: String {
+        get { name_ ?? "Unknown" }
+        set { name_ = newValue }
+    }
+    var summary: String {
+        get { summary_ ?? "Unknown" }
+        set { summary_ = newValue }
+    }
+    var startDate: Date {
+        get { startDate_ ?? Date() }
+        set { startDate_ = newValue }
+    }
+    var endDate: Date {
+        get { endDate_ ?? Date(timeInterval: 60 * 60 * 24, since: startDate) }
+        set { endDate_ = newValue }
+    }
+    var tasks: Set<Task> {
+        get { (tasks_ as? Set<Task>) ?? [] }
+        set { tasks_ = newValue as NSSet }
+    }
+}
+

--- a/i-scheduler/i-scheduler/Task.swift
+++ b/i-scheduler/i-scheduler/Task.swift
@@ -1,0 +1,71 @@
+//
+//  Task.swift
+//  i-scheduler
+//
+//  Created by sun on 2021/12/08.
+//
+
+import CoreData
+
+extension Task: Comparable {
+    public static func < (lhs: Task, rhs: Task) -> Bool {
+        lhs.name < rhs.name
+    }
+    
+    // MARK: - Fetching From CoreDate
+    
+    static func withId(_ id: UUID, context: NSManagedObjectContext) -> Task {
+        let request = fetchRequest(NSPredicate(format: "taskId_ = %@", id as CVarArg))
+        let task = (try? context.fetch(request)) ?? []
+        if let task = task.first {
+            return task
+        } else {
+            // TODO: - protect against nil before shipping
+            let newTask = Task(context: context)
+            newTask.taskId = id
+            newTask.project = Project.withId(UUID(), context: context)
+            return newTask
+        }
+    }
+    
+    static func fetchRequest(_ predicate: NSPredicate) -> NSFetchRequest<Task> {
+        let request = NSFetchRequest<Task>(entityName: "Task")
+        request.sortDescriptors = [NSSortDescriptor(key: "name_", ascending: true)]
+        request.predicate = predicate
+        return request
+    }
+    
+    // MARK: - Nil-coalesced Properties
+    
+    var taskId: UUID {
+        // TODO: maybe throw error when nil?
+        get { taskId_ ?? UUID() }
+        set { taskId_ = newValue }
+    }
+    var name: String {
+        get { name_ ?? "Unknown" }
+        set { name_ = newValue }
+    }
+    var summary: String {
+        get { summary_ ?? "Unknown" }
+        set { summary_ = newValue }
+    }
+    var startDate: Date {
+        get { startDate_ ?? Date() }
+        set { startDate_ = newValue }
+    }
+    var endDate: Date {
+        get { endDate_ ?? Date(timeInterval: 60 * 60 * 24, since: startDate) }
+        set { endDate_ = newValue }
+    }
+    var project: Project {
+        get { project_! }  // TODO: - protect against nil before app ships
+        set { project_ = newValue }
+    }
+    var startDateToEndDateInPrettyFormat : String {
+        let formatter = DateIntervalFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter.string(from: startDate, to: endDate)
+    }
+}

--- a/i-scheduler/i-scheduler/i_schedulerApp.swift
+++ b/i-scheduler/i-scheduler/i_schedulerApp.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import CoreData
 
 @main
 struct i_schedulerApp: App {
+    let persistenceController = PersistenceController.shared
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }
 }


### PR DESCRIPTION
**i_schedulerApp**
- persistenceController 변수 추가 

<br>

**i_scheduler.xcdatamodeld**
- 이름에서 i 다음의 하이픈("-")을 언더바("_")로 변경
    - NSPersistentContainer의 name 인자(Persistence파일 34번째 줄)에 맞춰서 변경함 
    - 우리 앱 이름이 i-scheduler인데 App 파일을 보면 이름이 i_scheduler임. 시스템상 하이픈 불가라 자동으로 변경된 것으로 보임
    - name인자는 자동으로 앱 이름이랑 동일하게 들어가는데 우리가 별도로 데이터 모델을 만들어주면서 데이터 모델은 파일명을 i-scheduler 라고 정해서 앱 실행 시 충돌이 발생해서 바꿔줌
- 매번 엔티티의 각 프로퍼티를 닐 코알리싱 하는 것을 막기 위해 extension에서 닐 코알리싱을 하는 연산 프로퍼티를 선언했는데 이름이 중복되는 것을 막기 위해 엔티티의 프로퍼티 이름 뒤에 언더바("_") 를 붙여줌
    - e.g. name_
- id 프로퍼티의 경우 Identifiable 프로토콜에 순응하기 위한 `id` 변수와 이름이 중복되어 각각 projectId_, taskId_ 로 변경 

<br>

**Project**
- 불 타입인 isFinshed 변수를 제외한 나머지 변수들은 닐 코알리싱된 연산 프로퍼티를 추가함
    - NSPredicate을 설정할 때를 제외하고는 연산프로퍼티를 이용해서 엔티티의 프로퍼티를 get/set 가능
- name을 기준으로 Comparable 프로토콜에 따르게 함
- 코어데이터로부터 데이터를 불러올 request를 만들 때 사용할 수 있는 fetchRequest(:) 함수 생성
- 코어데이터로부터 아이디를 사용해서 특정 프로젝트를 불러올 수 있는 withId(:context:) 함수 생성
- 추후 논의가 필요하다고 생각한 부분(닐 코알리싱을 할지 에러를 던지게 할지)은 TODO로 마크 해 둠

<br>

**Task**
- Project 와 동일
- 태스크 시작~끝 날짜를 보기 좋게 표현한 startDateToEndDateInPrettyFormat 변수 추가