### PR TITLE
[feat] refactored modifiedForPredicates method #47

### DIFF
--- a/i-scheduler/i-scheduler/TaskList.swift
+++ b/i-scheduler/i-scheduler/TaskList.swift
@@ -16,11 +16,10 @@ struct TaskList: View {
     init(isPresented: Binding<Bool>, project: Project, date: Date) {
         self._isPresented = isPresented
         self.project = project
-        let datePredicates = date.modifiedForPredicates()
         let request = Task.fetchRequest(
             NSPredicate(
                 format: "project_ = %@ and startDate_ < %@ and endDate_ >= %@",
-                argumentArray: [project, datePredicates.start, datePredicates.end]
+                argumentArray: [project, date.tomorrowMidnight, date.midnight]
         ))
         _tasks = FetchRequest(fetchRequest: request)
     }

--- a/i-scheduler/i-scheduler/UtilityExtensions.swift
+++ b/i-scheduler/i-scheduler/UtilityExtensions.swift
@@ -8,43 +8,18 @@
 import SwiftUI
 
 extension Date {
-    /// Returns a Tuple of two Dates where each represents the startDate and endDate
-    /// predicates to be used when creating a fetch request to fetch projects/tasks to be
-    /// done on this Date from Core Data
-    ///
-    /// To fetch all existing tasks on the given Date,  the predicates for startDate and
-    /// EndDate must be `startDate < mm/dd/yy 00:00:00 + 1 day` AND
-    /// `endDate >= mm/dd/yy 00:00:00`
-    /// - e.g. if the given Date is Jan 1, 2000 predicate for
-    ///     - startDate needs to be Jan 2, 2000, 00:00:00
-    ///     - endDate needs to be Jan 1, 2000, 00:00:00
-    /// - To get these predicates, this method calculates the date of the given Date's
-    ///   next day, converts each of the two Dates into a String and converts them back
-    ///   to Date
-    /// - `DateComponents` are used to get the next day's date because everyday
-    ///   is not 24 hours due to issues like summer time etc.
-    /// - then `DateFormatter` is used to convert Date into String in `mm/dd/yy`
-    ///   format (without time) and then back to Date again which then results in
-    ///   `mm/dd/yy 00:00:00`
-    ///
-    /// - Returns: `Tuple` of two `Dates` named `start` and `end` where
-    ///   each repsents the Date to be used as predicates for StartDate and EndDate
-    func modifiedForPredicates() -> (start: Date, end: Date) {
-        var components = DateComponents()
-        components.day = 1
-        let tomorrow = Calendar.current.date(byAdding: components, to: self)
-        
+    var midnight: Date {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .none
-        
-        let startDateString = formatter.string(from: tomorrow ?? Date())
-        let endDateString = formatter.string(from: self)
-        
-        let startDate = formatter.date(from: startDateString) ?? Date()
-        let endDate = formatter.date(from: endDateString) ?? Date()
-        
-        return (startDate, endDate)
+        let midnightString = formatter.string(from: self)
+        return formatter.date(from: midnightString) ?? self
+    }
+    
+    var tomorrowMidnight: Date {
+        var components = DateComponents()
+        components.day = 1
+        return Calendar.current.date(byAdding: components, to: midnight) ?? midnight
     }
 }
 


### PR DESCRIPTION
### 반영 위치 
- UtilityExtensions
- TaskList

### 반영 내용
- 기존의 modifiedForPredicates 메서드를 midnight, tomorrowMidnight 의 2개 프로퍼티로 분리
    - 네이밍 직관성을 높이고, tomorrowMidnight 의 경우 midnight 을 이용하여 연산 방법도 좀 더 단순화
- TaskList 에서 modifiedForPredicates 를 호출하던 부분도 맞춰서 수정 