### PR TITLE
[feat] Separate Edit/AddSheet and ToolBar #44

### DIFF
--- a/i-scheduler/i-scheduler/AddSheet.swift
+++ b/i-scheduler/i-scheduler/AddSheet.swift
@@ -8,64 +8,33 @@
 import SwiftUI
 import CoreData
 
-struct AddSheet: View {
-    @Environment(\.presentationMode) private var presentationMode
-    @StateObject var addData: TempData = TempData()
+struct ProjectAddSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
+    @ObservedObject private var tempProject: TempData = TempData()
     
-    private var subject: Subject
-    private var prefix: String
-    private var projectId: UUID?
-    
-    init(_ subject: Subject) {
-        switch subject {
-        case .project:
-            self.prefix = "프로젝트"
-        case .task:
-            self.prefix = "할 일"
-        }
-        
-        self.subject = subject
-    }
-    
-    // TODO: 프로젝트 시작, 종료 날짜에 맞춰 DatePicker 제한
-    
-    init(_ subject: Subject, projectId: UUID) {
-        switch subject {
-        case .project:
-            self.prefix = "프로젝트"
-        case .task:
-            self.prefix = "할 일"
-        }
-        
-        self.subject = subject
-        self.projectId = projectId
-    }
-    
+    private var prefix: String = "프로젝트"
+
     var body: some View {
         VStack {
-            if subject == .project {
-                AddToolBar(subject, addData: addData)
-            }
-            else {
-                AddToolBar(subject, addData: addData, projectId: projectId!)
-            }
+            ProjectToolBar(.add, project: nil, with: tempProject)
             Form {
                 Section(content: {
-                    TextField("", text: $addData.name)
+                    TextField("", text: $tempProject.name)
                 }, header: {
                     Text("\(prefix) 이름")
                 })
                 
                 Section(content: {
-                    TextEditor(text: $addData.summary)
+                    TextEditor(text: $tempProject.summary)
                         .modifier(TextEditorModifier())
                 }, header: {
                     Text("\(prefix) 설명")
                 })
                 
                 Section(content: {
-                    DatePicker("시작 날짜", selection: $addData.startDate, displayedComponents: .date)
-                    DatePicker("종료 날짜", selection: $addData.endDate, in: PartialRangeFrom(addData.startDate), displayedComponents: .date)
+                    DatePicker("시작 날짜", selection: $tempProject.startDate, displayedComponents: .date)
+                    DatePicker("종료 날짜", selection: $tempProject.endDate,
+                               in: PartialRangeFrom(tempProject.startDate), displayedComponents: .date)
                 }, header: {
                     Text("\(prefix) 기간")
                 })
@@ -74,8 +43,45 @@ struct AddSheet: View {
     }
 }
 
-//struct AddSheet_Previews: PreviewProvider {
-//    static var previews: some View {
-//        AddSheet(subject: .project)
-//    }
-//}
+struct TaskAddSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
+    @ObservedObject private var tempTask: TempData
+    
+    private var prefix: String = "할 일"
+    private var project: Project
+    
+    init(relatedTo project: Project) {
+        self.project = project
+        self.tempTask = TempData()
+        self.tempTask.startDate = project.startDate
+        self.tempTask.endDate = project.endDate
+    }
+    
+    var body: some View {
+        VStack {
+            TaskToolBar(.add, task: nil, with: tempTask, to: project)
+            Form {
+                Section(content: {
+                    TextField("", text: $tempTask.name)
+                }, header: {
+                    Text("\(prefix) 이름")
+                })
+                
+                Section(content: {
+                    TextEditor(text: $tempTask.summary)
+                        .modifier(TextEditorModifier())
+                }, header: {
+                    Text("\(prefix) 설명")
+                })
+                
+                Section(content: {
+                    DatePicker("시작 날짜", selection: $tempTask.startDate, displayedComponents: .date)
+                    DatePicker("종료 날짜", selection: $tempTask.endDate,
+                               in: PartialRangeFrom(tempTask.startDate), displayedComponents: .date)
+                }, header: {
+                    Text("\(prefix) 기간")
+                })
+            }
+        }
+    }
+}

--- a/i-scheduler/i-scheduler/EditSheet.swift
+++ b/i-scheduler/i-scheduler/EditSheet.swift
@@ -8,55 +8,105 @@
 import SwiftUI
 import CoreData
 
-
-struct EditSheet: View {
-    @Environment(\.managedObjectContext) var viewContext
-    @ObservedObject private var editData: TempData
+struct ProjectEditSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
+    @ObservedObject private var tempProject: TempData
     
-    private var subject: Subject
-    private var prefix: String
+    private var prefix: String = "프로젝트"
+    private var project: Project
     
-    
-    // TODO: 프로젝트 시작, 종료 날짜에 맞춰 DatePicker 제한
-    init(editWith selectedData: TempData, _ subject: Subject) {
-        switch subject {
-        case .project:
-            self.prefix = "프로젝트"
-        case .task:
-            self.prefix = "할 일"
-        }
+    init(editWith selectedProject: Project) {
+        self.project = selectedProject
+        self.tempProject = TempData()
         
-        self.subject = subject
-        self.editData = selectedData
+        self.tempProject.name = selectedProject.name
+        self.tempProject.summary = selectedProject.summary
+        self.tempProject.startDate = selectedProject.startDate
+        self.tempProject.endDate = selectedProject.endDate
+        self.tempProject.isFinished = selectedProject.isFinished
     }
     
     var body: some View {
         VStack {
-            EditToolBar(subject: subject, editedData: editData)
+            ProjectToolBar(.edit, project: project, with: tempProject)
             Form {
                 Section(content: {
-                    TextField("", text: $editData.name)
+                    TextField("", text: $tempProject.name)
                 }, header: {
                     Text("\(prefix) 이름")
                 })
                 
                 Section(content: {
-                    TextEditor(text: $editData.summary)
+                    TextEditor(text: $tempProject.summary)
                         .modifier(TextEditorModifier())
                 }, header: {
                     Text("\(prefix) 설명")
                 })
                 
                 Section(content: {
-                    DatePicker("시작 날짜", selection: $editData.startDate, displayedComponents: .date)
-                    DatePicker("종료 날짜", selection: $editData.endDate,
-                               in: PartialRangeFrom(editData.startDate), displayedComponents: .date)
+                    DatePicker("시작 날짜", selection: $tempProject.startDate, displayedComponents: .date)
+                    DatePicker("종료 날짜", selection: $tempProject.endDate,
+                               in: PartialRangeFrom(tempProject.startDate), displayedComponents: .date)
                 }, header: {
                     Text("\(prefix) 기간")
                 })
                 
                 Section(content: {
-                    Toggle("\(prefix) 완료", isOn: $editData.isFinished)
+                    Toggle("\(prefix) 완료", isOn: $tempProject.isFinished)
+                        .toggleStyle(.switch)
+                }, header: {
+                    Text("\(prefix) 완료")
+                })
+            }
+        }
+    }
+}
+
+struct TaskEditSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
+    @ObservedObject private var tempTask: TempData
+    
+    private var prefix: String = "할 일"
+    private var task: Task
+    
+    init(editWith selectedTask: Task) {
+        self.task = selectedTask
+        self.tempTask = TempData()
+        
+        self.tempTask.name = selectedTask.name
+        self.tempTask.summary = selectedTask.summary
+        self.tempTask.startDate = selectedTask.startDate
+        self.tempTask.endDate = selectedTask.endDate
+        self.tempTask.isFinished = selectedTask.isFinished
+    }
+    
+    var body: some View {
+        VStack {
+            TaskToolBar(.edit, task: task, with: tempTask, to: nil)
+            Form {
+                Section(content: {
+                    TextField("", text: $tempTask.name)
+                }, header: {
+                    Text("\(prefix) 이름")
+                })
+                
+                Section(content: {
+                    TextEditor(text: $tempTask.summary)
+                        .modifier(TextEditorModifier())
+                }, header: {
+                    Text("\(prefix) 설명")
+                })
+                
+                Section(content: {
+                    DatePicker("시작 날짜", selection: $tempTask.startDate, displayedComponents: .date)
+                    DatePicker("종료 날짜", selection: $tempTask.endDate,
+                               in: PartialRangeFrom(tempTask.startDate), displayedComponents: .date)
+                }, header: {
+                    Text("\(prefix) 기간")
+                })
+                
+                Section(content: {
+                    Toggle("\(prefix) 완료", isOn: $tempTask.isFinished)
                         .toggleStyle(.switch)
                 }, header: {
                     Text("\(prefix) 완료")
@@ -76,9 +126,3 @@ struct TextEditorModifier: ViewModifier {
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .center)
     }
 }
-
-//struct EditSheet_Previews: PreviewProvider {
-//    static var previews: some View {
-//        EditSheet(subject: .task)
-//    }
-//}

--- a/i-scheduler/i-scheduler/Enums.swift
+++ b/i-scheduler/i-scheduler/Enums.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Subject {
-    case project
-    case task
+enum Action {
+    case add
+    case edit
 }

--- a/i-scheduler/i-scheduler/ProjectList.swift
+++ b/i-scheduler/i-scheduler/ProjectList.swift
@@ -55,13 +55,13 @@ struct ProjectList: View {
                                 showAddSheet.toggle()
                             }
                             .sheet(isPresented: $showAddSheet, content: {
-                                AddSheet(.project)
+                                ProjectAddSheet()
                             })
                         }
                     })
                 }
                 .sheet(item: $project) { project in
-                    EditSheet(editWith: project, .project)
+                    ProjectEditSheet(editWith: project)
                 }
                 .environment(\.editMode, editMode)
             }
@@ -75,9 +75,3 @@ extension EditMode {
         self = self == .active ? .inactive : .active
     }
 }
-
-//struct ProjectList_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ProjectList()
-//    }
-//}

--- a/i-scheduler/i-scheduler/TemporaryModel.swift
+++ b/i-scheduler/i-scheduler/TemporaryModel.swift
@@ -7,14 +7,10 @@
 
 import Foundation
 
-// ProjectList에서 첫번째 sheet 업데이트되지 않는 것 -> @State 버그
-// 해결하기 위해 ObservableObject 사용
-
 class TempData: ObservableObject {
-        var id: UUID = UUID()
-        @Published var name: String = ""
-        @Published var summary: String = ""
-        @Published var startDate: Date = Date()
-        @Published var endDate: Date = Date(timeInterval: 60 * 60 * 24, since: Date())
-        @Published var isFinished: Bool = false
+    @Published var name: String = ""
+    @Published var summary: String = ""
+    @Published var startDate: Date = Date()
+    @Published var endDate: Date = Date(timeInterval: 60 * 60 * 24, since: Date())
+    @Published var isFinished: Bool = false
 }


### PR DESCRIPTION
### 반영 위치
ProjectList
각 Edit, Add Sheet 필요한 뷰들은 따로 수정하지 않음(테스트는 완료) -> 컨플릭트때문에 안 했는데 필요하면 코멘트 달아주세요!

### 변경 내용
1. EditSheet.swift
- ProjectEditSheet와 TaskEditSheet로 변경
- 각 수정할 대상 project, task를 인자로 넘기기
2. AddSheet.swift
- ProjectAddSheet와 TaskAddSheet로 변경
- 새로운 항목 추가이므로 전자는 아무 것도 넘길 필요 없음, 후자는 연결된 project 인자로 넘기기
3. ToolBar.swift
- ProjectToolBar와 TaskToolBar로 변경
- 앞의 Sheet에서 넘겨받은 데이터를 실제로 저장하는 시점
- 수정/추가할 데이터가 유효한 데이터인지(이름이 있는지, 시작과 끝 날짜가 반전되지 않았는지 등) 체크
    - Alert 객체 -> iOS15.0부터 .alert Modifier로 사용 -> **추후 수정**