### PR TITLE
[feat] Fix Task Add Sheet and Modified TempData #66

### DIFF
--- a/i-scheduler/i-scheduler/ProjectAddSheet.swift
+++ b/i-scheduler/i-scheduler/ProjectAddSheet.swift
@@ -10,7 +10,7 @@ import CoreData
 
 struct ProjectAddSheet: View {
     @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
-    @ObservedObject private var tempProject: TempData = TempData()
+    @State private var tempProject: TempData = TempData()
     
     private var prefix: String = "프로젝트"
 

--- a/i-scheduler/i-scheduler/ProjectEditSheet.swift
+++ b/i-scheduler/i-scheduler/ProjectEditSheet.swift
@@ -10,20 +10,13 @@ import CoreData
 
 struct ProjectEditSheet: View {
     @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
-    @ObservedObject private var tempProject: TempData
+    @State private var tempProject: TempData = TempData()
     
     private var prefix: String = "프로젝트"
     private var project: Project
     
     init(editWith selectedProject: Project) {
         self.project = selectedProject
-        self.tempProject = TempData()
-        
-        self.tempProject.name = selectedProject.name
-        self.tempProject.summary = selectedProject.summary
-        self.tempProject.startDate = selectedProject.startDate
-        self.tempProject.endDate = selectedProject.endDate
-        self.tempProject.isFinished = selectedProject.isFinished
     }
     
     var body: some View {
@@ -31,7 +24,9 @@ struct ProjectEditSheet: View {
             ProjectToolBar(.edit, project: project, with: tempProject)
             Form {
                 Section(content: {
-                    TextField("", text: $tempProject.name)
+                    VStack{
+                        TextField("", text: $tempProject.name)
+                    }
                 }, header: {
                     Text("\(prefix) 이름")
                 })
@@ -58,6 +53,9 @@ struct ProjectEditSheet: View {
                     Text("\(prefix) 완료")
                 })
             }
+        }
+        .onAppear {
+            self.tempProject.setSpecificProject(with: project)
         }
     }
 }

--- a/i-scheduler/i-scheduler/TaskAddSheet.swift
+++ b/i-scheduler/i-scheduler/TaskAddSheet.swift
@@ -10,18 +10,13 @@ import CoreData
 
 struct TaskAddSheet: View {
     @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
-    @ObservedObject private var tempTask: TempData
+    @State private var tempTask: TempData = TempData()
     
     private var prefix: String = "할 일"
     private var project: Project
     
-    // TODO: 실제 기기에서 textField, textEditor, DatePicker 선택시 초기화되는 오류 발생
-    // ObservedObject -> 계속 init됨
     init(relatedTo project: Project) {
         self.project = project
-        self.tempTask = TempData()
-        self.tempTask.startDate = project.startDate
-        self.tempTask.endDate = project.endDate
     }
     
     var body: some View {
@@ -49,6 +44,9 @@ struct TaskAddSheet: View {
                     Text("\(prefix) 기간")
                 })
             }
+        }
+        .onAppear {
+            self.tempTask.setSpecificDate(with: project.startDate, project.endDate)
         }
     }
 }

--- a/i-scheduler/i-scheduler/TaskEditSheet.swift
+++ b/i-scheduler/i-scheduler/TaskEditSheet.swift
@@ -10,20 +10,13 @@ import CoreData
 
 struct TaskEditSheet: View {
     @Environment(\.managedObjectContext) private var viewContext: NSManagedObjectContext
-    @ObservedObject private var tempTask: TempData
+    @State private var tempTask: TempData = TempData()
     
     private var prefix: String = "할 일"
     private var task: Task
     
     init(editWith selectedTask: Task) {
         self.task = selectedTask
-        self.tempTask = TempData()
-        
-        self.tempTask.name = selectedTask.name
-        self.tempTask.summary = selectedTask.summary
-        self.tempTask.startDate = selectedTask.startDate
-        self.tempTask.endDate = selectedTask.endDate
-        self.tempTask.isFinished = selectedTask.isFinished
     }
     
     var body: some View {
@@ -31,7 +24,9 @@ struct TaskEditSheet: View {
             TaskToolBar(.edit, task: task, with: tempTask, to: nil)
             Form {
                 Section(content: {
-                    TextField("", text: $tempTask.name)
+                    VStack {
+                        TextField("", text: $tempTask.name)
+                    }
                 }, header: {
                     Text("\(prefix) 이름")
                 })
@@ -58,6 +53,9 @@ struct TaskEditSheet: View {
                     Text("\(prefix) 완료")
                 })
             }
+        }
+        .onAppear {
+            self.tempTask.setSpecificTask(with: task)
         }
     }
 }

--- a/i-scheduler/i-scheduler/TemporaryModel.swift
+++ b/i-scheduler/i-scheduler/TemporaryModel.swift
@@ -7,10 +7,69 @@
 
 import Foundation
 
-class TempData: ObservableObject {
-    @Published var name: String = ""
-    @Published var summary: String = ""
-    @Published var startDate: Date = Date()
-    @Published var endDate: Date = Date(timeInterval: 60 * 60 * 24, since: Date())
-    @Published var isFinished: Bool = false
+//Edit시 계속 init 되는 현상때문에 사용X
+//class TempData: ObservableObject {
+//    @Published var name: String = ""
+//    @Published var summary: String = ""
+//    @Published var startDate: Date = Date()
+//    @Published var endDate: Date = Date(timeInterval: 60 * 60 * 24, since: Date())
+//    @Published var isFinished: Bool = false
+//
+//    func setSpecificProject(with project: Project) {
+//        self.name = project.name
+//        self.summary = project.summary
+//        self.startDate = project.startDate
+//        self.endDate = project.endDate
+//        self.isFinished = project.isFinished
+//    }
+//
+//    func setSpecificTask(with task: Task) {
+//        self.name = task.name
+//        self.summary = task.summary
+//        self.startDate = task.startDate
+//        self.endDate = task.endDate
+//        self.isFinished = task.isFinished
+//    }
+//
+//    func setSpecificDate(with startDate: Date, _ endDate: Date) {
+//        self.startDate = startDate
+//        self.endDate = endDate
+//    }
+//}
+
+struct TempData {
+    var name: String
+    var summary: String
+    var startDate: Date
+    var endDate: Date
+    var isFinished: Bool = false
+    
+    init() {
+        self.name = ""
+        self.summary = ""
+        self.startDate = Date()
+        self.endDate = Date(timeInterval: 60 * 60 * 24, since: Date())
+        self.isFinished = false
+    }
+    
+    mutating func setSpecificProject(with project: Project) {
+            self.name = project.name
+            self.summary = project.summary
+            self.startDate = project.startDate
+            self.endDate = project.endDate
+            self.isFinished = project.isFinished
+        }
+    
+    mutating func setSpecificTask(with task: Task) {
+            self.name = task.name
+            self.summary = task.summary
+            self.startDate = task.startDate
+            self.endDate = task.endDate
+            self.isFinished = task.isFinished
+        }
+    
+    mutating func setSpecificDate(with startDate: Date, _ endDate: Date) {
+            self.startDate = startDate
+            self.endDate = endDate
+        }
 }


### PR DESCRIPTION
### 반영 위치
Add/Edit Sheets

### 반영 내용
- 할 일 수정시, 프로젝트의 시작~종료 기간으로 데이트 피커 설정 시 문제 발생
- @ObservedObject가 아닌 @State 로 TempData 운용
  - 이 때, TextField에 초깃값 제대로 들어가지 않는 문제 발생
  - 해당 문제는 TextField를 VStack으로 감싸 해결