### PR TITLE
[feat] refactored coredata save method #27 #51

### DIFF
--- a/i-scheduler/i-scheduler/CheckBox.swift
+++ b/i-scheduler/i-scheduler/CheckBox.swift
@@ -13,25 +13,15 @@ struct CheckBox: View {
 
     var body: some View {
         Button {
-            // maybe take this to the extension
-            // make sth like func publish and put it in all the computed properties
             task.isFinished.toggle()
-//          replace this with
-//          PersistenceController.shared.saveContext()
-            save()
+            PersistenceController.shared.save(
+                errorDescription: "Error in Checkbox"
+            )
         } label: {
             Image(systemName: task.isFinished ? "checkmark.square" : "square")
                 .scaleEffect(1.3)
         }
         .buttonStyle(.plain)
-    }
-    
-    private func save() {
-        do {
-            try context.save()
-        } catch(let error) {
-            print("태스크 저장에 실패했습니다: \(error.localizedDescription)")
-        }
     }
 }
 

--- a/i-scheduler/i-scheduler/CheckBox.swift
+++ b/i-scheduler/i-scheduler/CheckBox.swift
@@ -8,30 +8,19 @@
 import SwiftUI
 
 struct CheckBox: View {
-    @Environment(\.managedObjectContext) var context
     @ObservedObject var task: Task
 
     var body: some View {
         Button {
-            // maybe take this to the extension
-            // make sth like func publish and put it in all the computed properties
             task.isFinished.toggle()
-//          replace this with
-//          PersistenceController.shared.saveContext()
-            save()
+            PersistenceController.shared.save(
+                errorDescription: "Error in Checkbox"
+            )
         } label: {
             Image(systemName: task.isFinished ? "checkmark.square" : "square")
                 .scaleEffect(1.3)
         }
         .buttonStyle(.plain)
-    }
-    
-    private func save() {
-        do {
-            try context.save()
-        } catch(let error) {
-            print("태스크 저장에 실패했습니다: \(error.localizedDescription)")
-        }
     }
 }
 

--- a/i-scheduler/i-scheduler/Persistence.swift
+++ b/i-scheduler/i-scheduler/Persistence.swift
@@ -52,4 +52,16 @@ struct PersistenceController {
             }
         })
     }
+    
+    func save(errorDescription: String = "") {
+        let context = container.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch(let error) {
+                // TODO: protect against b/f shipping!!!
+                fatalError(errorDescription + ": \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/i-scheduler/i-scheduler/PopupView.swift
+++ b/i-scheduler/i-scheduler/PopupView.swift
@@ -31,7 +31,6 @@ import SwiftUI
 import Combine
 
 extension View {
-
     public func popup<PopupContent: View>(
         isPresented: Binding<Bool>,
         type: Popup<PopupContent>.PopupType = .`default`,
@@ -281,8 +280,9 @@ public struct Popup<PopupContent>: ViewModifier where PopupContent: View {
 
     public func body(content: Content) -> some View {
         Group {
-            if showContent {
+            if isPresented {
                 main(content: content)
+                    .opacity(isPresented ? 1 : 0)
             } else {
                 content
             }
@@ -306,7 +306,7 @@ public struct Popup<PopupContent>: ViewModifier where PopupContent: View {
                 }
                 .edgesIgnoringSafeArea(.all)
                 .opacity(currentBackgroundOpacity)
-                .animation(animation)
+//                .animation(animation)
         }
         .overlay(sheet())
     }
@@ -339,7 +339,7 @@ public struct Popup<PopupContent>: ViewModifier where PopupContent: View {
                 .frameGetter($sheetContentRect)
                 .frame(width: screenWidth)
                 .offset(x: 0, y: currentOffset)
-                .animation(animation)
+//                .animation(animation)
         }
 
         #if !os(tvOS)
@@ -394,7 +394,9 @@ public struct Popup<PopupContent>: ViewModifier where PopupContent: View {
     
     private func dismiss() {
         dispatchWorkHolder.work?.cancel()
-        isPresented = false
+        withAnimation {
+            isPresented = false
+        }
         dismissCallback()
     }
 }
@@ -452,3 +454,6 @@ struct FrameGetter: ViewModifier {
             )
     }
 }
+
+
+

--- a/i-scheduler/i-scheduler/ProjectCalendarView.swift
+++ b/i-scheduler/i-scheduler/ProjectCalendarView.swift
@@ -81,7 +81,6 @@ struct ProjectCalendarView: View {
         self.dayData = Array(0...daysBetween(startDate: startDate, endDate: endDate))
     }
     var body: some View {
-
         GeometryReader { geometry in
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: UIDevice.current.userInterfaceIdiom != .pad ? 60 : 130))]) {
@@ -97,7 +96,9 @@ struct ProjectCalendarView: View {
             }
             .onChange(of: currentIndex) { index in
                 if index != nil {
-                    showModifyView.toggle()
+                    withAnimation {
+                        showModifyView.toggle()
+                    }
                     currentIndex = nil
                 }
             }
@@ -113,7 +114,9 @@ struct ProjectCalendarView: View {
             }
             .padding()
             .navigationBarTitle(project.name)
-            .navigationBarItems(trailing: NavigationTrailingEditButton(project: self.project))
+            .navigationBarItems(trailing: NavigationTrailingEditButton(project: self.project)
+                                    .disabled(showModifyView)
+            )
         }
     }
 }

--- a/i-scheduler/i-scheduler/ProjectList.swift
+++ b/i-scheduler/i-scheduler/ProjectList.swift
@@ -83,11 +83,9 @@ struct ProjectList: View {
         guard let index = indexSet.first else { fatalError("Cannot Convert IndexSet to Int") }
         
         viewContext.delete(projects[index])
-        do {
-            try viewContext.save()
-        } catch {
-            fatalError("Cannot save context")
-        }
+        PersistenceController.shared.save(
+            errorDescription: "Cannot save context"
+        )
     }
 }
 

--- a/i-scheduler/i-scheduler/ProjectToolBar.swift
+++ b/i-scheduler/i-scheduler/ProjectToolBar.swift
@@ -19,7 +19,7 @@ struct ProjectToolBar: View {
     private var barText: String
     private var project: Project?
     private var tempProject: TempData
-
+    
     init(_ action: ToolBarAction, project: Project?, with tempProject: TempData) {
         self.action = action
         self.barText = "프로젝트"
@@ -42,7 +42,7 @@ struct ProjectToolBar: View {
                 presentationMode.wrappedValue.dismiss()
             }
             .padding()
-
+            
             Spacer()
             Text(barText)
                 .font(.system(size: 20))
@@ -66,9 +66,9 @@ struct ProjectToolBar: View {
             .alert(isPresented: $showAlert) {
                 
                 // TODO: Alert 강종되는 오류 수정
-                    Alert(title: Text("제목을 추가해주세요!"), dismissButton: .cancel(Text("확인"), action: {
-                        showAlert.toggle()
-                    }))
+                Alert(title: Text("제목을 추가해주세요!"), dismissButton: .cancel(Text("확인"), action: {
+                    showAlert.toggle()
+                }))
             }
             .padding()
         }
@@ -107,11 +107,8 @@ struct ProjectToolBar: View {
     }
     
     private func saveContext() {
-        do {
-            try viewContext.save()
-        }
-        catch {
-            fatalError("Error in saveContext(): \(error.localizedDescription)")
-        }
+        PersistenceController.shared.save(
+            errorDescription: "Error in saveContext()"
+        )
     }
 }

--- a/i-scheduler/i-scheduler/TaskList.swift
+++ b/i-scheduler/i-scheduler/TaskList.swift
@@ -63,12 +63,9 @@ struct TaskList: View {
                 context.delete(task)
             }
         }
-        // replace with PersistenceController.shared.save()
-        do {
-            try context.save()
-        } catch(let error) {
-            print("태스크 삭제에 실패했습니다: \(error.localizedDescription)")
-        }
+        PersistenceController.shared.save(
+            errorDescription: "TaskList.deleteTask"
+        )
     }
     
     private var cancelButton: some View {

--- a/i-scheduler/i-scheduler/TaskToolBar.swift
+++ b/i-scheduler/i-scheduler/TaskToolBar.swift
@@ -115,11 +115,8 @@ struct TaskToolBar: View {
     }
     
     private func saveContext() {
-        do {
-            try viewContext.save()
-        }
-        catch {
-            fatalError("Error in saveContext(): \(error.localizedDescription)")
-        }
+        PersistenceController.shared.save(
+            errorDescription: "Error in saveContext()"
+        )
     }
 }


### PR DESCRIPTION
resolves #27 #51

### 적용위치
- Persistence
- CheckBox, TaskList, ProjectList, ProjectToolBar, TaskToolBar

### 적용내용
- Persistence 에 core data 에 저장 시 에러 처리 일관성 유지를 위해 save(errorDescription:) 메서드를 추가하고 기존의 개별 View 에 작성한 메서드 대체
- ProjectToolBar, TaskToolBar 의 경우 일단 saveContext() 메서드 자체는 그대로 두고 내부 구현 방식만 바꿈