### PR TITLE
[feat]refactoring_ProjectCalendarView #86

### DIFF
--- a/i-scheduler/i-scheduler.xcodeproj/project.pbxproj
+++ b/i-scheduler/i-scheduler.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		93989522276339E400BF6F59 /* TaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93989518276339E400BF6F59 /* TaskRowView.swift */; };
 		93989523276339E400BF6F59 /* ProjectCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93989519276339E400BF6F59 /* ProjectCalendarView.swift */; };
 		93989524276339E400BF6F59 /* TaskList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9398951A276339E400BF6F59 /* TaskList.swift */; };
+		93D34361277C48BF0011B539 /* ProjectCalendatButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D34360277C48BF0011B539 /* ProjectCalendatButtonView.swift */; };
 		A4162C53276B175E00A2BBDC /* Cardify.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4162C52276B175E00A2BBDC /* Cardify.swift */; };
 		A4162D2E2774C87500A2BBDC /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4162D2D2774C87400A2BBDC /* PopupView.swift */; };
 		A4162D4D2775AC0200A2BBDC /* ACarouselViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4162D482775AC0200A2BBDC /* ACarouselViewModel.swift */; };
@@ -50,6 +51,7 @@
 		93989518276339E400BF6F59 /* TaskRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskRowView.swift; sourceTree = "<group>"; };
 		93989519276339E400BF6F59 /* ProjectCalendarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectCalendarView.swift; sourceTree = "<group>"; };
 		9398951A276339E400BF6F59 /* TaskList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskList.swift; sourceTree = "<group>"; };
+		93D34360277C48BF0011B539 /* ProjectCalendatButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCalendatButtonView.swift; sourceTree = "<group>"; };
 		A4162C52276B175E00A2BBDC /* Cardify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cardify.swift; sourceTree = "<group>"; };
 		A4162D2D2774C87400A2BBDC /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		A4162D482775AC0200A2BBDC /* ACarouselViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ACarouselViewModel.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				93989511276339E300BF6F59 /* ProjectEditSheet.swift */,
 				A88F9AA627744E4600831DD3 /* TaskEditSheet.swift */,
 				93989519276339E400BF6F59 /* ProjectCalendarView.swift */,
+				93D34360277C48BF0011B539 /* ProjectCalendatButtonView.swift */,
 				A4162D2D2774C87400A2BBDC /* PopupView.swift */,
 				A4162C52276B175E00A2BBDC /* Cardify.swift */,
 				93989517276339E400BF6F59 /* ProjectGrid.swift */,
@@ -242,6 +245,7 @@
 				A4162D4E2775AC0200A2BBDC /* ACarousel.swift in Sources */,
 				A4162C53276B175E00A2BBDC /* Cardify.swift in Sources */,
 				A4162D512775AC0200A2BBDC /* AppLifeCycleModifier.swift in Sources */,
+				93D34361277C48BF0011B539 /* ProjectCalendatButtonView.swift in Sources */,
 				A4162D502775AC0200A2BBDC /* ACarouselAutoScroll.swift in Sources */,
 				A88F9AA727744E4600831DD3 /* TaskEditSheet.swift in Sources */,
 				A88F9AA927744E8000831DD3 /* TaskAddSheet.swift in Sources */,

--- a/i-scheduler/i-scheduler/ProjectCalendarView.swift
+++ b/i-scheduler/i-scheduler/ProjectCalendarView.swift
@@ -7,62 +7,7 @@
 
 import SwiftUI
 
-struct NavigationTrailingEditButton: View {
-    @State var showModifyTab: Bool = false
-    @State var project: Project
-    
-    var body: some View {
-        Button {
-            self.showModifyTab = !self.showModifyTab
-        } label: {
-            Text("수정")
-        }
-        .sheet(isPresented: $showModifyTab) {
-            ProjectEditSheet(editWith: project)
-        }
-    }
-}
 
-struct DayButtonView: View {
-    let day: Int
-    let date: Date
-    static let dateformat: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M.d"
-        return formatter
-    }()
-    
-    // MARK: colorOpacity - TaskList에서 할일의 개수를 받아와서 사용 예정
-    let colorOpacity: Double = 20
-
-    let width: CGFloat = UIScreen.main.bounds.size.width
-    let height: CGFloat = UIScreen.main.bounds.size.height
-    var body: some View {
-        ZStack {
-            Image(systemName: "square.fill")
-                .resizable()
-                .frame(width: UIDevice.current.userInterfaceIdiom != .pad ? width / 7 : width / 10,
-                       height: UIDevice.current.userInterfaceIdiom != .pad ? height / 12 : height / 11)
-                .foregroundColor(colorOpacity == 20 ? .white : Color(red: 117/255, green: 249/255, blue: 217/255))
-                .opacity(colorOpacity == 20 ? 1 : colorOpacity / 100)
-                .shadow(color: .black, radius: 2)
-            VStack {
-                Text(String(day))
-                    .fontWeight(.bold)
-                    .multilineTextAlignment(.center)
-                    .frame(alignment: .center)
-                    .foregroundColor(date.midnight == Date().midnight ? .accentColor : .black)
-                    .font(UIDevice.current.userInterfaceIdiom != .pad ? .title3 : .title2)
-                    .padding(2.0)
-                Text("\(date, formatter: DayButtonView.dateformat)")
-                    .lineLimit(1)
-                    .font(UIDevice.current.userInterfaceIdiom != .pad ? .footnote : .title3)
-                    .foregroundColor(date.midnight == Date().midnight ? .accentColor : .black)
-            }
-        }
-        .padding(5)
-    }
-}
 
 struct ProjectCalendarView: View {
     let startDate: Date
@@ -70,7 +15,7 @@ struct ProjectCalendarView: View {
     let dayData: [Int]
     
     @ObservedObject var project: Project
-    @State private var showModifyView: Bool = false
+    @State private var isShowModifyView: Bool = false
     @State private var currentIndex: Int?
     @State private var carouselIndex: Int = 0
 
@@ -89,7 +34,7 @@ struct ProjectCalendarView: View {
                             currentIndex = day
                             carouselIndex = day
                         } label: {
-                            DayButtonView(day: day + 1, date: plusDays(startDate: startDate, dayOf: day))
+                            DayButtonView(dayOfTheWeek: day + 1, displayedDate: plusDays(startDate: startDate, dayOf: day))
                         }
                     }
                 }
@@ -97,15 +42,15 @@ struct ProjectCalendarView: View {
             .onChange(of: currentIndex) { index in
                 if index != nil {
                     withAnimation {
-                        showModifyView.toggle()
+                        isShowModifyView.toggle()
                     }
                     currentIndex = nil
                 }
             }
-            .popup(isPresented: $showModifyView, dragToDismiss: true, closeOnTap: false, closeOnTapOutside: true) {
+            .popup(isPresented: $isShowModifyView, dragToDismiss: true, closeOnTap: false, closeOnTapOutside: true) {
                 ACarousel(dayData, index: $carouselIndex) { index in
                     TaskList(
-                      isPresented: $showModifyView,
+                      isPresented: $isShowModifyView,
                       project: project,
                       date: plusDays(startDate: startDate, dayOf: index)
                     )
@@ -114,28 +59,28 @@ struct ProjectCalendarView: View {
             }
             .padding()
             .navigationBarTitle(project.name)
-            .navigationBarItems(trailing: NavigationTrailingEditButton(project: self.project)
-                                    .disabled(showModifyView)
+            .navigationBarItems(trailing: ProjectCalendarNavigationTrailingEditButton(project: self.project)
+                                    .disabled(isShowModifyView)
             )
         }
     }
 }
 
-func daysBetween(startDate: Date, endDate: Date) -> Int {
+fileprivate func daysBetween(startDate: Date, endDate: Date) -> Int {
     if endDate < startDate {
         return 1
     }
     return Calendar.current.dateComponents([.day], from: removeUnderHour(fromDate: startDate), to: removeUnderHour(fromDate: endDate)).day!
 }
 
-func removeUnderHour(fromDate: Date) -> Date {
+fileprivate func removeUnderHour(fromDate: Date) -> Date {
     guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: fromDate)) else {
         fatalError("Failed to strip time from Date object")
     }
     return date
 }
 
-func plusDays(startDate: Date, dayOf: Int) -> Date {
+fileprivate func plusDays(startDate: Date, dayOf: Int) -> Date {
     var dateComponent = DateComponents()
     dateComponent.day = dayOf
     return Calendar.current.date(byAdding: dateComponent, to: startDate)!

--- a/i-scheduler/i-scheduler/ProjectCalendatButtonView.swift
+++ b/i-scheduler/i-scheduler/ProjectCalendatButtonView.swift
@@ -1,0 +1,92 @@
+//
+//  ProjectCalendatButtonView.swift
+//  i-scheduler
+//
+//  Created by Kim TaeSoo on 2021/12/29.
+//
+
+import SwiftUI
+
+struct ProjectCalendarNavigationTrailingEditButton: View {
+    @State var isShowModifyTab: Bool = false
+    @State var project: Project
+    
+    var body: some View {
+        Button {
+            self.isShowModifyTab = !self.isShowModifyTab
+        } label: {
+            Text("수정")
+        }
+        .sheet(isPresented: $isShowModifyTab) {
+            ProjectEditSheet(editWith: project)
+        }
+    }
+}
+
+struct DayButtonImageView: View {
+    let buttonViewColorOpacity: Double
+    let screenWidth: CGFloat
+    let screenHeight: CGFloat
+    var body: some View {
+        Image(systemName: "square.fill")
+            .resizable()
+            .frame(width: UIDevice.current.userInterfaceIdiom != .pad ? screenWidth / 7 : screenWidth / 10,
+                   height: UIDevice.current.userInterfaceIdiom != .pad ? screenHeight / 12 : screenHeight / 11)
+            .foregroundColor(buttonViewColorOpacity == 20 ? .white : Color(red: 117/255, green: 249/255, blue: 217/255))
+            .opacity(buttonViewColorOpacity == 20 ? 1 : buttonViewColorOpacity / 100)
+            .shadow(color: .black, radius: 2)
+    }
+}
+
+struct DayOfTheWeekTextView: View {
+    let dayOfTheWeek: Int
+    let displayedDate: Date
+    var body: some View {
+        Text(String(dayOfTheWeek))
+            .fontWeight(.bold)
+            .multilineTextAlignment(.center)
+            .frame(alignment: .center)
+            .foregroundColor(displayedDate.midnight == Date().midnight ? .accentColor : .black)
+            .font(UIDevice.current.userInterfaceIdiom != .pad ? .title3 : .title2)
+            .padding(2.0)
+    }
+    
+}
+
+struct DisplayDateTextView: View {
+    static let dateformat: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M.d"
+        return formatter
+    }()
+    
+    let displayedDate: Date
+    
+    var body: some View {
+        Text("\(displayedDate, formatter: DisplayDateTextView.dateformat)")
+            .lineLimit(1)
+            .font(UIDevice.current.userInterfaceIdiom != .pad ? .footnote : .title3)
+            .foregroundColor(displayedDate.midnight == Date().midnight ? .accentColor : .black)
+    }
+}
+
+struct DayButtonView: View {
+    let dayOfTheWeek: Int
+    let displayedDate: Date
+
+    // MARK: colorOpacity - TaskList에서 할일의 개수를 받아와서 사용 예정
+    let buttonViewColorOpacity: Double = 20
+
+    let screenWidth: CGFloat = UIScreen.main.bounds.size.width
+    let screenHeight: CGFloat = UIScreen.main.bounds.size.height
+    var body: some View {
+        ZStack {
+            DayButtonImageView(buttonViewColorOpacity: buttonViewColorOpacity, screenWidth: screenWidth, screenHeight: screenHeight)
+            VStack {
+                DayOfTheWeekTextView(dayOfTheWeek: dayOfTheWeek, displayedDate: displayedDate)
+                DisplayDateTextView(displayedDate: displayedDate)
+            }
+        }
+        .padding(5)
+    }
+}


### PR DESCRIPTION
1. 기존의 ProjectCalendarView파일을 줄 수가 길어짐에 따라 가독성을 높히고자  ProjectCalendarView, ProjectCalendarButtonView로 분할하였습니다.

2. ProjectCalendarView파일 내의 함수를 다른 파일에서 이용 하실 것 같지 않아서  fileprivate으로 수정하였습니다. 혹시 필요하시다면 private풀고 사용하시면 될 것 같습니다.

3. 네이밍의 일부를 조금 더 명확하게 하기위해 수정했습니다.

4. 네이밍 같은 경우에는 진행됨에 따라 계속 수정 할 예정이며 혹시 신박한 네이밍이 생각나시면 comment 남겨주시면 감사하겠습니다.